### PR TITLE
Lower existing MAX_DURATION from 75 to 60 seconds

### DIFF
--- a/src/chalicelib/bot_utils.py
+++ b/src/chalicelib/bot_utils.py
@@ -10,7 +10,7 @@ TELEGRAM_PARSE_MODE = 'HTML'
 # Although file_utils has an implementation for splitting long audio files before sending to Wit.AI
 # And although the maximum duration is 300 seconds (5 minutes) for Wit.AI
 # The bot is not behaving as expected for audios longer than ~75s, so I'm hard capping this for now
-MAX_DURATION = 75
+MAX_DURATION = 60
 
 __user_ids = os.environ.get('user_ids')
 user_ids = [int(user_id) for user_id in filter(None, re.split(r'[,;]', __user_ids))] if __user_ids else None


### PR DESCRIPTION
Transcription errors for audios longer than 60 seconds, triggering retries (3x)